### PR TITLE
Error in XPN_MLE: sign of b

### DIFF
--- a/CONOR/src/XPN_MLE.c
+++ b/CONOR/src/XPN_MLE.c
@@ -87,7 +87,7 @@ void XPN_MLE_C_C(double *xbar, double *A, double *b, double *c, double *s2, doub
 		}
 		
 		if (sumb < 0) {
-			for(i=1;i<I;i++){
+			for(i=0;i<I;i++){
 				b[i] = -1*b[i];
 			}
 			sumb = -1*sumb;


### PR DESCRIPTION
When correcting the sign of `b` coefficients, first element is skipped, but is should not be.

See line 266 of original Matlab code.
